### PR TITLE
Support falsey argument values

### DIFF
--- a/lib/n1_loader/core/loader.rb
+++ b/lib/n1_loader/core/loader.rb
@@ -23,7 +23,9 @@ module N1Loader
 
         @arguments ||= []
 
-        define_method(name) { args[name] ||= opts[:default]&.call }
+        define_method(name) do
+          args.fetch(name) { opts[:default]&.call }
+        end
 
         @arguments << opts.merge(name: name)
       end

--- a/lib/n1_loader/core/loader.rb
+++ b/lib/n1_loader/core/loader.rb
@@ -24,7 +24,7 @@ module N1Loader
         @arguments ||= []
 
         define_method(name) do
-          args.fetch(name) { opts[:default]&.call }
+          args.fetch(name) { args[name] = opts[:default]&.call }
         end
 
         @arguments << opts.merge(name: name)

--- a/spec/n1_loader_spec.rb
+++ b/spec/n1_loader_spec.rb
@@ -213,6 +213,12 @@ RSpec.describe N1Loader do
                                                                            ])
     end
 
+    it "supports falsey argument values" do
+      expect(object.with_default_argument(anything: 2)).to eq([object, [], 2])                      # default value
+      expect(object.with_default_argument(something: false, anything: 2)).to eq([object, false, 2]) # false
+      expect(object.with_default_argument(something: nil, anything: 2)).to eq([object, nil, 2])     # nil
+    end
+
     it "works with preloading" do
       N1Loader::Preloader.new(objects).preload(:with_arguments)
 

--- a/spec/n1_loader_spec.rb
+++ b/spec/n1_loader_spec.rb
@@ -232,7 +232,7 @@ RSpec.describe N1Loader do
     end
 
     it "caches based on arguments" do
-      N1Loader::Preloader.new(objects).preload(:with_arguments)
+      N1Loader::Preloader.new(objects).preload(:with_arguments, :with_default_argument)
 
       expect do
         objects.each { |object| object.with_arguments(something: "something", anything: "anything") }
@@ -248,6 +248,14 @@ RSpec.describe N1Loader do
 
       expect do
         objects.each { |object| object.with_arguments(something: "something", anything: "anything") }
+      end.not_to change(klass, :count)
+
+      expect do
+        objects.each { |object| object.with_default_argument(something: false, anything: nil) }
+      end.to change(klass, :count).by(1)
+
+      expect do
+        objects.each { |object| object.with_default_argument(something: false, anything: nil) }
       end.not_to change(klass, :count)
     end
 


### PR DESCRIPTION
Currently, falsey argument values are not supported due to the use of conditional assignment in the argument getter method defined dynamically in `N1Loader::Loader::argument`:
```ruby
define_method(name) { args[name] ||= opts[:default]&.call }
```
Also, as a side-effect, the `@args` attribute is being mutated by the method call:
```ruby
class IsolatedLoader < N1Loader::Loader
  argument :something

  def perform(_elements)
    args      # => { something: false }
    something # => nil
    args      # => { something: nil }
  end
end
```
This PR adds support for falsey argument values and also prevents the mutation of the `@args` attribute when retrieving the argument value via the dynamically defined getter method.