### PR TITLE
Loader#loaded: avoid elements size check if possible

### DIFF
--- a/lib/n1_loader/core/loader.rb
+++ b/lib/n1_loader/core/loader.rb
@@ -110,7 +110,7 @@ module N1Loader
 
       @loaded = {}.compare_by_identity
 
-      if elements.size == 1 && respond_to?(:single)
+      if respond_to?(:single) && elements.size == 1
         fulfill(elements.first, single(elements.first))
       elsif elements.any?
         perform(elements)


### PR DESCRIPTION
Only check if `elements.size == 1` when the `#single` method is defined. 
This helps to avoid unnecessary `SELECT COUNT(*)` queries when working with ActiveRecord relations.

I was also thinking about getting rid of the `elsif elements.any?` check as well. :thinking: 
But then decided that some loaders might actually depend on it.